### PR TITLE
Stub project should not use autoload or files section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,13 @@
     "license": "PHP",
     "require": {
         "php": ">=5.1.0"
+    },
+    "autoload": {
+        "psr-0": {
+            "": "src"
+        },
+        "files": [
+            "src/AMQP.php"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,5 @@
     "license": "PHP",
     "require": {
         "php": ">=5.1.0"
-    },
-    "autoload": {
-        "psr-0": {
-            "": "src"
-        },
-	"files": [
-	    "src/AMQP.php"
-	]
     }
 }

--- a/src/AMQP.php
+++ b/src/AMQP.php
@@ -1,4 +1,7 @@
 <?php
+if (defined('AMQP_NOPARAM')) {
+    return;
+}
 
 define('AMQP_NOPARAM', 0);
 define('AMQP_DURABLE', 2);


### PR DESCRIPTION
Why this is a problem. Composer autoload add files as auto require file at composer autoload startup. And you got lots of errors like this:

Notice: Constant AMQP_OS_SOCKET_TIMEOUT_ERRNO already defined in /.../vendor/empi89/php-amqp-stubs/src/AMQP.php on line 23

Other reason is IDE do not require files to be in composer autload. 

What do you think?
