### PR TITLE
Remove composer autoload settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,10 @@
     "license": "PHP",
     "require": {
         "php": ">=5.1.0"
+    },
+    "autoload": {
+        "files": [
+            "src/AMQP.php"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,5 @@
     "license": "PHP",
     "require": {
         "php": ">=5.1.0"
-    },
-    "autoload": {
-        "psr-0": {
-            "": "src"
-        },
-        "files": [
-            "src/AMQP.php"
-        ]
     }
 }


### PR DESCRIPTION
As these are only stub classes, we should not add them to composers autoload mechanism.
