### PR TITLE
Remove autoloading for stub classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,5 @@
     "license": "PHP",
     "require": {
         "php": ">=5.1.0"
-    },
-    "autoload": {
-        "psr-0": {
-            "": "src"
-        },
-        "files": [
-            "src/AMQP.php"
-        ]
     }
 }


### PR DESCRIPTION
Stub classes are not working implementation. Registering them in the autoloader is a bad idea. It means that the autoloader would try to load the stubs in case the extension is missing instead of complaining that classes don't exist
